### PR TITLE
change certificates path

### DIFF
--- a/deployment/webapp_staging.yaml
+++ b/deployment/webapp_staging.yaml
@@ -25,16 +25,16 @@ spec:
         livenessProbe:
           httpGet:
             # Path to probe; should be cheap, but representative of typical behavior
-            path: /index.html
-            port: 443
-            scheme: https
+            path: /heartbeat
+            port: 8090
+            scheme: http
           initialDelaySeconds: 30
           periodSeconds: 10
         ports:
         - containerPort: 443
         - containerPort: 80
         volumeMounts:
-        - mountPath: /usr/share/nginx_crt
+        - mountPath: /usr/share/nginx
           name: cert-volume
         env:
         - name: ENSEMBL_API_KEY


### PR DESCRIPTION
also cheaper http only endpoint, which may still be a requirement for the google load balancer.